### PR TITLE
Add Nix build support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+# Contributed by TRONG
+
+{
+  description = "Build the HayBox firmware";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, ... }@inputs: inputs.utils.lib.eachSystem [
+    "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin"
+  ] (system: let
+    pkgs = import nixpkgs {
+      inherit system;
+    };
+  in {
+    devShells.default = pkgs.mkShell rec {
+      name = "trongbox";
+
+      packages = with pkgs; [
+        # Build Tools
+        platformio-core
+        pico-sdk
+        avrdude
+        openocd
+        elfutils
+        # Build Dependencies
+        gcc-arm-embedded
+        python3
+        udev
+      ];
+    };
+
+    packages.buildBox = pkgs.buildFHSUserEnv {
+      name = "gcc-arm-env";
+      targetPkgs = pkgs: [
+        pkgs.platformio-core
+        pkgs.pico-sdk
+        pkgs.avrdude
+        pkgs.openocd
+        pkgs.elfutils
+        pkgs.gcc-arm-embedded
+        pkgs.python3
+        pkgs.udev
+      ];
+    };
+  });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     };
   in {
     devShells.default = pkgs.mkShell rec {
-      name = "trongbox";
+      name = "haybox";
 
       packages = with pkgs; [
         # Build Tools

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,8 @@ build_flags =
 	-I include/
 build_src_filter =
 	+<src/>
+upload_port =
+upload_protocol = custom
 
 [avr_base]
 platform = atmelavr


### PR DESCRIPTION
In order to build the HayBox firmware on Nix systems clone the git repository & run:
```
$ nix run .#buildBox
$ ./build.sh
```
you can find the firmware in `.pio/build/${profile}/`